### PR TITLE
Remove runs-on matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,7 @@ on:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -21,10 +18,6 @@ jobs:
     - run: npm install
 
     - run: xvfb-run -a npm test
-      if: runner.os == 'Linux'
-    
-    - run: npm test
-      if: runner.os != 'Linux'
 
     - name: Publish
       if: success()


### PR DESCRIPTION
### Description of your changes
The previous commit included an OS matrix that at this time is unnecessary and resulted in publishing failures.

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.
