### PR TITLE
Update activationEvents to narrow the watched scope

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,4 +32,5 @@ build.ext: install
 	@yarn compile
 
 package: build.ext
+	@mkdir -p ./out
 	@yarn vsce package -o ./out/

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ operator, we hope this extension enhances your development experience.
   and the [VS Code Up extension].
   * [Managing extensions in VS Code].
 * **Step 2.** To activate the extension, open any directory or workspace
-  containing a Crossplane package.
+  containing a Crossplane package (i.e. one that contains a `crossplane.yaml`).
 
 
 ## Features

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
  "displayName": "Up",
  "preview": true,
  "publisher": "upboundio",
- "version": "0.0.4",
+ "version": "0.0.5",
  "description": "Crossplane package support for Visual Studio Code",
  "main": "./dist/extension.js",
  "repository": {
@@ -15,7 +15,9 @@
   "url": "https://github.com/upbound/vscode-up/issues"
  },
  "activationEvents": [
-  "onLanguage:yaml"
+   "workspaceContains:crossplane.yaml",
+   "workspaceContains:*/crossplane.yaml",
+   "workspaceContains:*/*/crossplane.yaml"
  ],
  "engines": {
   "vscode": "^1.52.0"


### PR DESCRIPTION
### Description of your changes
Prior to this change, VSCode would activate the extension if there was simply a `yaml` file detected in the workspace. This hand the unfortunate consequence of sending invalid workspaces to `xpls` for it to unnecessarily process.

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
I have verified that the above changes:
- keeps xpls from being run against a crossplane package workspace that does not include a `crossplane.yaml`
- keeps xpls from being run against a repo (golang) that does not include a `crossplane.yaml`
