### PR TITLE
Update name to `upbound`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
  "icon": "media/logo.png",
- "name": "up",
- "displayName": "Up",
+ "name": "upbound",
+ "displayName": "Upbound",
  "preview": true,
  "publisher": "upboundio",
- "version": "0.0.6",
+ "version": "0.0.7",
  "description": "Crossplane package support for Visual Studio Code",
  "main": "./dist/extension.js",
  "repository": {


### PR DESCRIPTION
### Description of your changes
Per #13 , we'd like to update the extension's displayName from `up` and `Up` to `upbound` and `Upbound`.

Fixes #13 

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Verified locally that the extension has the expected appearance:
<img width="538" alt="Screen Shot 2022-02-07 at 8 25 22 AM" src="https://user-images.githubusercontent.com/2375126/152829169-1199f989-8c20-4f51-b88d-d924c58152d3.png">

