### PR TITLE
Move the version back to v.0.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
  "displayName": "Upbound",
  "preview": true,
  "publisher": "upboundio",
- "version": "0.0.7",
+ "version": "0.0.1",
  "description": "Crossplane package support for Visual Studio Code",
  "main": "./dist/extension.js",
  "repository": {


### PR DESCRIPTION
### Description of your changes
The extension renaming in #14 ended up creating a new extension in the marketplace. Per the discussion in #14 , we'll reset the version back to `v0.0.1`

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.
