### PR TITLE
Add note for minimum version of `up` to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ operator, we hope this extension enhances your development experience.
 
 * **Step 1.** If you haven't done so already, install the latest version of [Up]
   and the [VS Code Up extension].
+  * If you currently have `up` installed, make sure you are using at least version `v0.8.0`.
+    * You can check your version by running `up --version`.
   * [Managing extensions in VS Code].
 * **Step 2.** To activate the extension, open any directory or workspace
   containing a Crossplane package (i.e. one that contains a `crossplane.yaml`).

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
  "displayName": "Upbound",
  "preview": true,
  "publisher": "upboundio",
- "version": "0.0.2",
+ "version": "0.0.3",
  "description": "Crossplane package support for Visual Studio Code",
  "main": "./dist/extension.js",
  "repository": {


### PR DESCRIPTION
### Description of your changes
Prior to this change, there wasn't an explicit note that `up` needed to be >= to a certain version, so users may have thought they were on a reasonable version when that in fact was not true.

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Verified the README rendered correctly.
