### PR TITLE
Update references to `crossplane` to `upbound` and vscode-up

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ details how contributors are expected to conduct themselves as part of the
 Crossplane community.
 
 ## Contributing Code
-To contribute bug fixes or features to Crossplane:
+To contribute bug fixes or features to vscode-up:
 
 1. Communicate your intent.
 1. Make your changes.
@@ -19,14 +19,14 @@ To contribute bug fixes or features to Crossplane:
 1. Update documentation and examples where appropriate.
 1. Open a Pull Request (PR).
 
-Communicating your intent lets the Crossplane maintainers know that you intend
+Communicating your intent lets the Upbound maintainers know that you intend
 to contribute, and how. This sets you up for success - you can avoid duplicating
 an effort that may already be underway, adding a feature that may be rejected,
 or heading down a path that you would be steered away from at review time. The
 best way to communicate your intent is via a detailed GitHub issue. Take a look
 first to see if there's already an issue relating to the thing you'd like to
 contribute. If there isn't, please raise a new one! Let us know what you'd like
-to work on, and why. The Crossplane maintainers can't always triage new issues
+to work on, and why. The Upbound maintainers can't always triage new issues
 immediately, but we encourage you to bring them to our attention via [Slack].
 
 Be sure to practice [good git commit hygiene] as you make your changes. All but

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ See [CONTRIBUTING.md]
 [Apache 2.0 license](LICENSE)
 
 <!-- Named Links -->
-[CONTRIBUTING.md]: CONTRIBUTING.md
+[CONTRIBUTING.md]: https://github.com/upbound/vscode-up/blob/main/CONTRIBUTING.md
 [filing an issue]: https://github.com/upbound/vscode-up/issues/new/choose
 [starting a GitHub discussion]: https://github.com/upbound/vscode-up/discussions
 [LICENSE]: LICENSE

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
  "displayName": "Upbound",
  "preview": true,
  "publisher": "upboundio",
- "version": "0.0.4",
+ "version": "0.0.5",
  "description": "Crossplane package support for Visual Studio Code",
  "main": "./dist/extension.js",
  "repository": {


### PR DESCRIPTION
### Description of your changes
The Crossplane contributing guide was used as a north star for much of the CONTRIBUTING.md doc that exists in this repo. Unfortunately, some of the original `Crossplane` references were not cleaned up prior to its publishing here. 

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Verified the CONTRIBUTING.md doc rendered correctly.
