### PR TITLE
feat: configurable up binary path

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -3,8 +3,6 @@ import * as child_process from 'child_process';
 import {
 	LanguageClient,
 	LanguageClientOptions,
-	ServerOptions,
-	Executable,
 } from 'vscode-languageclient';
 
 let client: LanguageClient;
@@ -36,12 +34,19 @@ export function deactivate(): Thenable<void> | undefined {
 }
 
 async function spawnServer(): Promise<child_process.ChildProcess> {
-	let serverProcess = child_process.spawn('up', ['xpls', 'serve', '--verbose'])
-	// let serverProcess = child_process.spawn('')
-    serverProcess.on('error', (err: { code?: string; message: string }) => {
+  let settings = getSettings()
+  let serverProcess = child_process.spawn(settings.upPath, ['xpls', 'serve', '--verbose'])
+	serverProcess.on('error', (err: { code?: string; message: string }) => {
 		window.showWarningMessage(
 			`Failed to spawn xpls: \`${err.message}\``
 		)
 	})
     return serverProcess
+}
+
+function getSettings(): {upPath: any} {
+	const configUpPath = workspace.getConfiguration().get('xpls.up.path');
+	return {
+		upPath: configUpPath ? configUpPath : "up"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,12 @@
    "type": "object",
    "title": "xpls",
    "properties": {
+     "xpls.up.path": {
+       "scope": "workspace",
+       "type": "string",
+       "default": "up",
+       "description": "Path to the up CLI, requires a MANUAL WINDOW RELOAD to be effective."
+     },
     "xpls.maxNumberOfProblems": {
      "scope": "resource",
      "type": "number",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,5 @@
   },
   "exclude": [
     "node_modules"
-  ],
+  ]
 }


### PR DESCRIPTION

Signed-off-by: Philippe Scorsolini <p.scorsolini@gmail.com>

### Description of your changes

The extension was crashing at launch because of it not being able to find the "up" binary in the path, making it configurable and setting it to the correct value fixed the issue. The configuration change requires a manual reload of the vscode window, which can be done from the command palette, "Developer: Reload Window". In the future we could think of implementing automatic restart on this parameter change.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Locally installing the extension.