### PR TITLE
docs: fix link to up CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,6 @@ See [CONTRIBUTING.md]
 [LICENSE]: LICENSE
 [Managing extensions in VS Code]: https://code.visualstudio.com/docs/editor/extension-gallery
 [Slack]: https://crossplane.slack.com/messages/upbound/
-[Up]: https://github.com/upbound/up
+[Up]: https://docs.upbound.io/manuals/cli/overview/https://github.com/upbound/up
 [VS Code Up extension]: https://marketplace.visualstudio.com/items?itemName=Upboundio.upbound
-[`xpls`]: https://github.com/upbound/up
+[`xpls`]: https://github.com/upbound/uphttps://docs.upbound.io/reference/cli-reference/#up-xpls


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

http://github.com/upbound/up seems to be a private repo, so it is better to point users to open sources to get the CLI tool.

Fixes #30 

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
  No this didn't work:
  ```
  $ make reviewable
  make: *** No rule to make target 'reviewable'.  Stop.
  ```
  
  This may be in one of the submodules, so I tried `make submodules`, but this failed as well:
  
  ```
  ...
  git@github.com: Permission denied (publickey).
  fatal: Could not read from remote repository.

  Please make sure you have the correct access rights
  and the repository exists.
  ```
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.
  Not appropriate in this case, I think.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

URLs are being checked to ensure they are accessible to everyone.